### PR TITLE
Add non-blocking cycle

### DIFF
--- a/md5-server_amd64.go
+++ b/md5-server_amd64.go
@@ -67,7 +67,7 @@ func NewServer() Server {
 	md5srv := &md5Server{}
 	md5srv.digests = make(map[uint64][Size]byte)
 	md5srv.newInput = make(chan newClient, Lanes)
-	md5srv.cycle = make(chan uint64, Lanes)
+	md5srv.cycle = make(chan uint64, Lanes*10)
 	md5srv.uidCounter = md5ServerUID - 1
 	if !hasAVX512 {
 		// only reserve memory when not on AVX512


### PR DESCRIPTION
Only add cycle if we know this is the last write or buffer is full.
Extend cycle buffer to 640 entries now that we have smaller blocks.

Improves ability to fill up all lanes.

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkAvx2/32KB-32              242239        233346        -3.67%
BenchmarkAvx2/64KB-32              382258        352720        -7.73%
BenchmarkAvx2/128KB-32             664247        613375        -7.66%
BenchmarkAvx2/256KB-32             1254980       1159022       -7.65%
BenchmarkAvx2/512KB-32             2411834       2347587       -2.66%
BenchmarkAvx2/1MB-32               4809084       4723287       -1.78%
BenchmarkAvx2/2MB-32               9731707       9579398       -1.57%
BenchmarkAvx2/4MB-32               19314698      19142243      -0.89%
BenchmarkAvx2/8MB-32               38492552      38169903      -0.84%
BenchmarkAvx2Parallel/32KB-32      19958         16866         -15.49%
BenchmarkAvx2Parallel/64KB-32      33771         27883         -17.44%
BenchmarkAvx2Parallel/128KB-32     59582         50308         -15.57%
BenchmarkAvx2Parallel/256KB-32     108715        94854         -12.75%
BenchmarkAvx2Parallel/512KB-32     204728        188343        -8.00%
BenchmarkAvx2Parallel/1MB-32       392877        375319        -4.47%
BenchmarkAvx2Parallel/2MB-32       780891        744599        -4.65%
BenchmarkAvx2Parallel/4MB-32       1531194       1492799       -2.51%
BenchmarkAvx2Parallel/8MB-32       3118666       3029631       -2.85%

benchmark                          old MB/s     new MB/s     speedup
BenchmarkAvx2/32KB-32              2164.34      2246.83      1.04x
BenchmarkAvx2/64KB-32              2743.11      2972.82      1.08x
BenchmarkAvx2/128KB-32             3157.19      3419.04      1.08x
BenchmarkAvx2/256KB-32             3342.13      3618.83      1.08x
BenchmarkAvx2/512KB-32             3478.10      3573.29      1.03x
BenchmarkAvx2/1MB-32               3488.65      3552.02      1.02x
BenchmarkAvx2/2MB-32               3447.95      3502.77      1.02x
BenchmarkAvx2/4MB-32               3474.50      3505.80      1.01x
BenchmarkAvx2/8MB-32               3486.85      3516.32      1.01x
BenchmarkAvx2Parallel/32KB-32      26269.21     31085.46     1.18x
BenchmarkAvx2Parallel/64KB-32      31049.56     37606.90     1.21x
BenchmarkAvx2Parallel/128KB-32     35197.63     41685.87     1.18x
BenchmarkAvx2Parallel/256KB-32     38580.57     44218.36     1.15x
BenchmarkAvx2Parallel/512KB-32     40974.42     44539.05     1.09x
BenchmarkAvx2Parallel/1MB-32       42703.45     44701.20     1.05x
BenchmarkAvx2Parallel/2MB-32       42969.39     45063.78     1.05x
BenchmarkAvx2Parallel/4MB-32       43827.80     44955.07     1.03x
BenchmarkAvx2Parallel/8MB-32       43036.90     44301.68     1.03x

benchmark                          old allocs     new allocs     delta
BenchmarkAvx2/32KB-32              48             49             +2.08%
BenchmarkAvx2/64KB-32              60             59             -1.67%
BenchmarkAvx2/128KB-32             84             82             -2.38%
BenchmarkAvx2/256KB-32             132            129            -2.27%
BenchmarkAvx2/512KB-32             228            225            -1.32%
BenchmarkAvx2/1MB-32               421            417            -0.95%
BenchmarkAvx2/2MB-32               806            801            -0.62%
BenchmarkAvx2/4MB-32               1574           1569           -0.32%
BenchmarkAvx2/8MB-32               3113           3105           -0.26%
BenchmarkAvx2Parallel/32KB-32      53             48             -9.43%
BenchmarkAvx2Parallel/64KB-32      67             60             -10.45%
BenchmarkAvx2Parallel/128KB-32     94             84             -10.64%
BenchmarkAvx2Parallel/256KB-32     145            132            -8.97%
BenchmarkAvx2Parallel/512KB-32     245            231            -5.71%
BenchmarkAvx2Parallel/1MB-32       443            424            -4.29%
BenchmarkAvx2Parallel/2MB-32       833            812            -2.52%
BenchmarkAvx2Parallel/4MB-32       1609           1587           -1.37%
BenchmarkAvx2Parallel/8MB-32       3165           3136           -0.92%

benchmark                          old bytes     new bytes     delta
BenchmarkAvx2/32KB-32              5477          5510          +0.60%
BenchmarkAvx2/64KB-32              6534          6442          -1.41%
BenchmarkAvx2/128KB-32             8656          8455          -2.32%
BenchmarkAvx2/256KB-32             13146         12722         -3.23%
BenchmarkAvx2/512KB-32             21960         21582         -1.72%
BenchmarkAvx2/1MB-32               39693         39267         -1.07%
BenchmarkAvx2/2MB-32               75129         74592         -0.71%
BenchmarkAvx2/4MB-32               145880        145239        -0.44%
BenchmarkAvx2/8MB-32               287616        286600        -0.35%
BenchmarkAvx2Parallel/32KB-32      6537          5733          -12.30%
BenchmarkAvx2Parallel/64KB-32      8031          7020          -12.59%
BenchmarkAvx2Parallel/128KB-32     11027         9673          -12.28%
BenchmarkAvx2Parallel/256KB-32     17598         15164         -13.83%
BenchmarkAvx2Parallel/512KB-32     30929         27688         -10.48%
BenchmarkAvx2Parallel/1MB-32       61945         59316         -4.24%
BenchmarkAvx2Parallel/2MB-32       144091        128317        -10.95%
BenchmarkAvx2Parallel/4MB-32       344810        338001        -1.97%
BenchmarkAvx2Parallel/8MB-32       1059675       1042525       -1.62%
```