### PR TITLE
Use cpuid/v2

### DIFF
--- a/block16_amd64_test.go
+++ b/block16_amd64_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 func reverse(s string) string {
@@ -174,7 +174,7 @@ func TestBlock16Masked(t *testing.T) {
 }
 
 func BenchmarkBlock8(b *testing.B) {
-	if !cpuid.CPU.AVX2() {
+	if !cpuid.CPU.Supports(cpuid.AVX2) {
 		b.SkipNow()
 	}
 

--- a/block_amd64.go
+++ b/block_amd64.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 var hasAVX512 bool
@@ -83,7 +83,7 @@ var avx512md5consts = func(c []uint32) []uint32 {
 }(md5consts[:])
 
 func init() {
-	hasAVX512 = cpuid.CPU.AVX512F()
+	hasAVX512 = cpuid.CPU.Supports(cpuid.AVX512F)
 }
 
 // Interface function to assembly code

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/minio/md5-simd
 
 go 1.14
 
-require github.com/klauspost/cpuid v1.2.3
+require github.com/klauspost/cpuid/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
-github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid/v2 v2.0.2 h1:pd2FBxFydtPn2ywTLStbFg9CJKrojATnpeJWSP7Ys4k=
+github.com/klauspost/cpuid/v2 v2.0.2/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/md5-server_amd64.go
+++ b/md5-server_amd64.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 // MD5 initialization constants
@@ -60,7 +60,7 @@ type md5Server struct {
 
 // NewServer - Create new object for parallel processing handling
 func NewServer() Server {
-	if !cpuid.CPU.AVX2() {
+	if !cpuid.CPU.Supports(cpuid.AVX2) {
 		return &fallbackServer{}
 	}
 	md5srv := &md5Server{}

--- a/md5_amd64_test.go
+++ b/md5_amd64_test.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 )
 
 const benchmarkWithSum = true
@@ -194,7 +194,7 @@ func BenchmarkAvx2(b *testing.B) {
 }
 
 func BenchmarkAvx2Parallel(b *testing.B) {
-	if !cpuid.CPU.AVX2() {
+	if !cpuid.CPU.Supports(cpuid.AVX2) {
 		b.SkipNow()
 	}
 	restore := hasAVX512


### PR DESCRIPTION
This keeps it go get-able without Go modules.