### PR TITLE
Preserve RBP register

### DIFF
--- a/md5block_amd64.s
+++ b/md5block_amd64.s
@@ -4,8 +4,12 @@
 // +build !noasm
 // +build gc
 
+#include "textflag.h"
+
 // func blockScalar(dig *[4]uint32, p []byte)
-TEXT ·blockScalar(SB), $0-32
+// Requires: SSE2
+TEXT ·blockScalar(SB), NOSPLIT, $0-32
+	MOVQ BP, X0
 	MOVQ p_len+16(FP), AX
 	MOVQ dig+0(FP), CX
 	MOVQ p_base+8(FP), DX
@@ -711,4 +715,5 @@ loop:
 	MOVL CX, 12(AX)
 
 end:
+	MOVQ X0, BP
 	RET


### PR DESCRIPTION
Spill it to XMM in the scalar version.

> See discussion on Slack and `golang-dev`
>
> https://gophers.slack.com/archives/C6WDZJ70S/p1598210629000900
> https://groups.google.com/g/golang-dev/c/aLn9t8tKg2o/m/Kw-N7lUuBAAJ
>
> Summary:
>
> * `BP` should be callee-save (poorly documented, even some standard library assembly didn't handle this correctly until recently)
> * `BP` "will be saved automatically if there is a nonzero frame size" https://golang.org/cl/248260
>
> * Use the "nonzero frame size" hack in the case where `BP` has been used