### PR TITLE
Allow to disable AVX512 (for CPUs with throttling)

### DIFF
--- a/block_amd64.go
+++ b/block_amd64.go
@@ -87,8 +87,8 @@ var avx512md5consts = func(c []uint32) []uint32 {
 }(md5consts[:])
 
 // Interface function to assembly code
-func (s *md5Server) blockMd5_x16(d *digest16, input [16][]byte, half bool) {
-	if hasAVX512 {
+func (s *md5Server) blockMd5_x16(d *digest16, input [16][]byte, half bool, useAVX512 bool) {
+	if hasAVX512 && useAVX512 {
 		blockMd5_avx512(d, input, s.allBufs, &s.maskRounds16)
 		return
 	}

--- a/md5-server_fallback.go
+++ b/md5-server_fallback.go
@@ -10,3 +10,7 @@ package md5simd
 func NewServer() *fallbackServer {
 	return &fallbackServer{}
 }
+
+func NewServerWithOptions(opts ServerOptions) *fallbackServer {
+	return &fallbackServer{}
+}

--- a/md5.go
+++ b/md5.go
@@ -22,6 +22,10 @@ type Server interface {
 	Close()
 }
 
+type ServerOptions struct {
+	UseAVX512 bool
+}
+
 type Hasher interface {
 	hash.Hash
 	Close()


### PR DESCRIPTION
Hi, on some CPUs AVX512 usage leads to throttling and AVX2 version gives overall better performance. For these CPUs it might have sense to be able to disable AVX512.