### PR TITLE
fix: use Get to retrive object from Pool (#33, #35)

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - master
     - main
+  workflow_dispatch:
 jobs:
   vulncheck:
     name: Analysis

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19 ]
+        go-version: [ 1.23 ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/md5.go
+++ b/md5.go
@@ -34,7 +34,7 @@ type Hasher interface {
 // StdlibHasher returns a Hasher that uses the stdlib for hashing.
 // Used hashers are stored in a pool for fast reuse.
 func StdlibHasher() Hasher {
-	return &md5Wrapper{Hash: md5Pool.New().(hash.Hash)}
+	return &md5Wrapper{Hash: md5Pool.Get().(hash.Hash)}
 }
 
 // md5Wrapper is a wrapper around the builtin hasher.
@@ -52,7 +52,7 @@ type fallbackServer struct {
 
 // NewHash -- return regular Golang md5 hashing from crypto
 func (s *fallbackServer) NewHash() Hasher {
-	return &md5Wrapper{Hash: md5Pool.New().(hash.Hash)}
+	return &md5Wrapper{Hash: md5Pool.Get().(hash.Hash)}
 }
 
 func (s *fallbackServer) Close() {


### PR DESCRIPTION
In fact, the caller should call `sync.Pool.Get()` to retrive 'empty' object from pool instead of manually creating an object every time with `New()`, which is a bad idea that never ever reuse the objects.

The `Get()` method would reuse the former object or create a new one if no more to return.

go reference: https://pkg.go.dev/sync#Pool.Get

```
Get selects an arbitrary item from the [Pool](https://pkg.go.dev/sync#Pool), removes it from the Pool, and returns it to the caller. Get may choose to ignore the pool and treat it as empty. Callers should not assume any relation between values passed to [Pool.Put](https://pkg.go.dev/sync#Pool.Put) and the values returned by Get.

If Get would otherwise return nil and p.New is non-nil, Get returns the result of calling p.New.
```